### PR TITLE
Refactor Instagram bot to support multiple accounts and follow settin…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 # User config files
 config.json
 session.json
+/settings
+/followed_users
 
 # C extensions
 *.so

--- a/example.config.json
+++ b/example.config.json
@@ -1,15 +1,19 @@
 {
-    "account": {
-            "username": "username",
-            "password": "password"
-    },
-    "source_accounts": [
-        "instagram"
-    ],
-    "followers_index_limit": 5,
-    "daily_follow_limit": 100,
-    "daily_unfollow_limit": 24,
-    "follow_interval": [900, 1600],
-    "unfollow_interval": [450, 800],
-    "unfollow_after": 86400
-}
+    "accounts": [
+      {
+        "username": "account1_username",
+        "password": "account1_password",
+        "source_account": "source_account_username",
+        "follows_per_day": 50,
+        "unfollow_after": 84600
+      },
+      {
+        "username": "account2_username",
+        "password": "account2_password",
+        "source_account": "source_account_username",
+        "follows_per_day": 50,
+        "unfollow_after": 84600
+      }
+    ]
+  }
+

--- a/instabot/utils.py
+++ b/instabot/utils.py
@@ -26,7 +26,6 @@ logging.basicConfig(
 )
 logger = logging.getLogger()
 
-session_file_path = 'settings.json'
 
 def load_config(file_path: str) -> dict:
     with open(file_path, 'r') as file:
@@ -90,6 +89,10 @@ def next_proxy() -> str:
 
 
 def get_client(username: str, password: str) -> Union[Client, None]:
+    settings_folder = "settings"
+    os.makedirs(settings_folder, exist_ok=True)
+    session_file_path = os.path.join(settings_folder, f"settings_{username}.json")
+
     def handle_exception(client: Client, e: Exception) -> Union[bool, None]:
         nonlocal username, password
         if isinstance(e, BadPassword):
@@ -137,7 +140,7 @@ def get_client(username: str, password: str) -> Union[Client, None]:
 
     cl = Client()
 
-    if os.path.exists('settings.json'):
+    if os.path.exists(session_file_path):
         cl.load_settings(session_file_path)
         try:
             cl.get_timeline_feed()  # Check if the session is valid

--- a/main.py
+++ b/main.py
@@ -1,22 +1,38 @@
 import instabot
 import threading
 
-if __name__ == "__main__":
-    config = instabot.load_config('config.json')
+def run_bot(account):
+    username = account['username']
+    password = account['password']
+    source_account = account['source_account']
+    follows_per_day = account['follows_per_day']
+    unfollow_after = account['unfollow_after']
 
-    ACCOUNT_USERNAME = config['account']['username']
-    ACCOUNT_PASSWORD = config['account']['password']
-    SOURCE_ACCOUNT = config['source_account']
-    FOLLOWS_PER_DAY = config['follows_per_day']
-
-    cl = instabot.get_client(ACCOUNT_USERNAME, ACCOUNT_PASSWORD)
+    cl = instabot.get_client(username, password)
 
     while True:
-        follow_thread = threading.Thread(target=instabot.follow_users, args=(cl, SOURCE_ACCOUNT, FOLLOWS_PER_DAY))
-        unfollow_thread = threading.Thread(target=instabot.unfollow_users, args=(cl, config))
+        follow_thread = threading.Thread(target=instabot.follow_users, args=(cl, source_account, follows_per_day))
+        unfollow_thread = threading.Thread(target=instabot.unfollow_users, args=(cl, unfollow_after))
 
         follow_thread.start()
         unfollow_thread.start()
 
         follow_thread.join()
         unfollow_thread.join()
+
+if __name__ == "__main__":
+    config = instabot.load_config('config.json')
+
+    # Get the accounts from the configuration file
+    accounts = config['accounts']
+
+    # Create a thread for each account and run the bot
+    account_threads = []
+    for account in accounts:
+        account_thread = threading.Thread(target=run_bot, args=([account]))
+        account_threads.append(account_thread)
+        account_thread.start()
+
+    # Wait for all account threads to finish
+    for account_thread in account_threads:
+        account_thread.join()


### PR DESCRIPTION
…gsThis commit refactors the Instagram bot to support multiple accounts and their respective follow settings. The bot now loads accounts from the configuration file and creates a separate thread for each account to run the bot. The follow settings for each account are now stored in the configuration file, and the bot now supports following a set number of users per day and unfollowing users after a set period. The code has also been updated to handle file I/O in a more robust manner by creating folders if they do not exist and using the appropriate file paths